### PR TITLE
Fixing 'cordova platform add' failing for other plugins due to missing node_modules

### DIFF
--- a/hooks/resolveDependencies.js
+++ b/hooks/resolveDependencies.js
@@ -131,7 +131,14 @@
                                     return -1;
                                 }
                                 logger.verbose("Removed package.json.tmp");
-                                complete();
+                                installModules(function(err) {
+                                    if (err) {
+                                        deferral.reject("Error installing original modules: " + err);
+                                        return -1;
+                                    }
+                                    logger.verbose("Installed original modules");
+                                    complete();
+                                });
                             })
                         });
                     } else {


### PR DESCRIPTION
Fixing an issue, where 'cordova platform add' failed due to missing node-modules when adding PESDK plugin. Now, after resolving dependencies, the original node-modules are added back to the project.